### PR TITLE
bug: restricted the dates before the current one

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
           class="js-name-input"
           maxlength="120"
         />
-        <input type="date" class="js-date-input" />
+        <input type="date" class="js-date-input" min=""/>
         <input type="time" class="js-time-input" />
         <select class="js-category-input">
           <option value="">Select Category</option>

--- a/script.js
+++ b/script.js
@@ -190,6 +190,7 @@ function setDefaultDateTime() {
   const time = now.toTimeString().split(' ')[0].slice(0, 5);
 
   inputDateElement.value = date;
+  inputDateElement.min = date;  // Set the min attribute to today's date
   inputTimeElement.value = time;
 }
 


### PR DESCRIPTION
## Description

Restricted the dates before the current one by making changes in the Java Script and HTML code.

Fixes #101

## Type of change

- [ ] Bug fix (non-breaking change)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so that they can be reproduced.

![image](https://github.com/user-attachments/assets/103e2bbe-77bb-4d46-babe-8ccbd33de428)
 Now the dates are shown in grey hence restricted.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
