### PR TITLE
Fixed Overlaping of container and footer

### DIFF
--- a/style.css
+++ b/style.css
@@ -23,6 +23,7 @@ body {
   max-width: 1000px;
   padding: 20px;
   box-sizing: border-box;
+  margin-bottom: 170px;
 }
 
 .subtitle {


### PR DESCRIPTION
Fixed Overlaping of container and footer with margins

Description:
Fixed Overlaping of container and footer with margins

Fixes :
https://github.com/Groverio/To-Do-List/issues/104
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so that they can be reproduced.

- [x] Test A
Cross-browser testing to see if the feature works on Chrome, Firefox, etc.
Mobile and desktop testing for responsive design.
Fixed Overlaping of container and footer with margins
after images:
![Screenshot 2024-10-13 000945](https://github.com/user-attachments/assets/19a2e063-238d-4a83-88f1-3b22f8793bb6)
after adding items:
![Screenshot 2024-10-13 000936](https://github.com/user-attachments/assets/ebb990fe-772b-4dbb-ba4e-f873d34515fa)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
