### PR TITLE
Ensure task containers adjust size for longer task names

### DIFF
--- a/style.css
+++ b/style.css
@@ -113,6 +113,7 @@ h1 {
 
 .js-add-html {
   display: grid;
+  align-items: center;
   grid-template-columns: 3fr 1fr 1fr 1fr 1fr;
   gap: 10px;
   height: 25px;
@@ -121,15 +122,17 @@ h1 {
 .small-container {
   display: flex;
   justify-content: flex-start;
-  align-items: end;
+  align-items: center;
   border: 1px solid #ccc;
   padding: 10px 15px;
   border-radius: 5px;
   background-color: #fff;
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
-  min-height: 3px;
   text-align: left;
-  height: 25px;
+  min-height: 45px;
+  max-height: 90px;
+  height: auto;
+  box-sizing: border-box;
 }
 
 .task-info {
@@ -142,6 +145,8 @@ h1 {
 
 .task-name {
   font-weight: bold;
+  overflow: auto;
+  max-height: 40px;
 }
 
 .category-tag,


### PR DESCRIPTION
## Description

Modified the CSS of the website, specifically the "small-container" and "task-name" classes, to accommodate longer task names.

![image](https://github.com/user-attachments/assets/da4f65b8-52f2-4297-ab0a-fa85707ee9af)

Fixes [#110](https://github.com/Groverio/To-Do-List/issues/110)

## Type of change

- [ ] Bug fix (non-breaking change)

## How Has This Been Tested?

The HTML file was run directly using Live Server and tested in a browser.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
