### PR TITLE
Fixed invalid/past time or date inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -648,7 +648,6 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-15.11.0.tgz",
       "integrity": "sha512-yeyNSjdbyVaWurlwCpcA6XNBrHTMIeDdj0/hnvX/OLJ9ekOXYbLsLinH/MucQyGvNnXhidTdNhTtJaffL2sMfw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },

--- a/script.js
+++ b/script.js
@@ -70,7 +70,7 @@ function addTodo() {
   }
 
   // Check that time is not in past
-  if (time < inputTimeElement.min) {
+  if (time < inputTimeElement.min && date === inputDateElement.min) {
     alert('Please select a future time.');
     return;
   }

--- a/script.js
+++ b/script.js
@@ -39,6 +39,18 @@ function addTodo() {
     return;
   }
 
+  // Check that date is not in past
+  if (date < inputDateElement.min) {
+    alert('Please select the current date or a future date.');
+    return;
+  }
+
+  // Check that time is not in past
+  if (time < inputTimeElement.min) {
+    alert('Please select a future time.');
+    return;
+  }
+
   if (isEditing) {
     // Update the existing todo
     todoList[editIndex] = {
@@ -192,6 +204,7 @@ function setDefaultDateTime() {
   inputDateElement.value = date;
   inputDateElement.min = date; // Set the min attribute to today's date
   inputTimeElement.value = time;
+  inputTimeElement.min = time; // Set the min attribute to current time
 }
 
 function sortTodos(sortBy) {


### PR DESCRIPTION
## Description

I noticed that a user was able to create a habit and set the date to a past date by physically changing the date from the calander input, I also noticed the user could set a time that had already happend. Eg: It is 16:35 and you could create a habit and set it for 10:30 which doesn't make any sense. I implemented simple validation checks to ensure habits with past date or times cannot be added.

Fixes #148

## Bug Fix


Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so that they can be reproduced.

- [ ] Test A -> Attempted to add past dates for different habits
- [ ] Test B -> Attempted to add past times for different habits
- [ ] Test C -> Ensured normal habit addition still worked as before

## Checklist:

- [ ] My code follows the style guidelines of this project Yes
- [ ] I have performed a self-review of my code Yes
- [ ] I have commented my code, particularly in hard-to-understand areas Yes
- [ ] I have made corresponding changes to the documentation Yes
- [ ] My changes generate no new warnings Yes
- [ ] Any dependent changes have been merged and published in downstream modules Yes
