### PR TITLE
Fix responsive layout for .subtitle and .sort-buttons on screens below 947px

### DIFF
--- a/style.css
+++ b/style.css
@@ -24,7 +24,7 @@ why-need-link {
   border-radius: 5px;
   transition: background-color 0.3s ease;
 }
-. .container {
+ .container {
   width: 100%;
   max-width: 1000px;
   padding: 20px;
@@ -427,6 +427,11 @@ Animating title
 
   .subtitle {
     font-size: 3rem;
+    margin: 0;
+  }
+
+  .sort-buttons{
+    justify-content: center;
   }
 
   .js-add-grid,


### PR DESCRIPTION
This PR modifies the styling for screen widths below 947px, specifically targeting .subtitle and .sort-buttons.

Removed the top and bottom margin for the .subtitle class to improve visual consistency in smaller viewports.
Centered the content of the .sort-buttons class for better alignment on narrower screens.
Fixes #(issue number)

Type of change
 Bug fix (non-breaking change)
How Has This Been Tested?
The following tests were performed to ensure the changes work correctly across relevant screen sizes:

 Verified that the .subtitle no longer has top or bottom margins on screens narrower than 947px.
 Checked that the .sort-buttons are centered correctly when the screen width is below 947px.
Checklist:
 My code follows the style guidelines of this project
 I have performed a self-review of my code
 I have commented my code, particularly in hard-to-understand areas
 I have made corresponding changes to the documentation
 My changes generate no new warnings
 Any dependent changes have been merged and published in downstream modules