### PR TITLE
Fix: Adjust container responsiveness for small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -671,3 +671,8 @@ Animating title
     width: 200px;
   }
 }
+@media screen and (max-width: 420px) {  
+  .container {     
+   margin-top: 10px;   
+     max-width: 100%;   } 
+   }


### PR DESCRIPTION
Fix: Adjust container responsiveness for small screens

- Added a media query for screens with a max-width of 420px to improve layout 
  on mobile devices.
- Set `margin-top: 10px` to provide consistent spacing on smaller screens.
- Applied `max-width: 100%` to ensure the container scales within the viewport 
  and does not overflow.

This change ensures the container adapts properly to smaller screen sizes, 
enhancing the mobile user experience.


**Before**

![screencapture-127-0-0-1-5500-Todo-html-2024-10-30-01_11_12](https://github.com/user-attachments/assets/6b235677-6873-4e02-9b09-d35f00dbbee0)

**After**

![screencapture-127-0-0-1-5500-Todo-html-2024-10-30-01_30_34](https://github.com/user-attachments/assets/e5b6c684-f9fa-48f9-b066-bf3ced48340a)
